### PR TITLE
Enable deploy to article page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Get the deployed links: `gulp url`
 The link can be pasted into a Composer file 
 
 
+### Deploy to article page
+
+Before deploying to article page, do the following:
+
+1. Comment out code under INTERACTIVE header in `main.js` and uncomment code under ARTICLE header.
+2. Comment out `@import "dcr_enhancer";` in `main.scss`
+3. Change path in `config.json` to prevent overwriting atom for interactive page.
+
 ### Testing in apps
 
 To test on the Guardian apps - follow our 

--- a/atoms/default/client/css/main.scss
+++ b/atoms/default/client/css/main.scss
@@ -5,6 +5,7 @@
 @import "scrolly";
 @import "dcr_enhancer"; // default left column enhancer, works with inline, showcase and immersive weighting
 // @import "full_immersive_enhancer"; // full-width enhancer, to be used with immersive weighting. Removes left colum, sets 100vw atom width at any breakpoint
+// @import "debug"; // for debugging in article page. REMOVE IN PRODUCTION!!
 
 /*----- Vertical scrollbar width used for sizing full viewport width elements -----*/
 root {

--- a/atoms/default/client/js/main.js
+++ b/atoms/default/client/js/main.js
@@ -1,8 +1,26 @@
+/**** INTERACTIVE ****/ 
+
 var el = document.createElement('script');
 el.src = '<%= atomPath %>/app.js';
 document.body.appendChild(el);
 
+/**** ARTICLE PAGE ****/ 
 
+// const styles = [].slice.apply(document.querySelectorAll("style"));
+// const wrapper = document.querySelector("#scrolly-1");
+// const parentPage = window.parent.document;
+
+// styles.forEach((style) => {
+//   parentPage.body.appendChild(style);
+// });
+
+// window.frameElement.parentNode.innerHTML = wrapper.outerHTML;
+
+// var el = parentPage.createElement("script");
+// el.src = "<%= atomPath %>/app.js";
+// parentPage.body.appendChild(el);
+
+/**** EVERYTHING ELSE ****/ 
 
 setTimeout(() => {
   if (window.resize) {  

--- a/shared/css/_debug.scss
+++ b/shared/css/_debug.scss
@@ -1,0 +1,20 @@
+//------- JUST FOR DEBUGGING. REMOVE IN PRODUCTION!! --------//
+
+figure {
+    @include mq(tablet) {
+        width: 740px;
+    }
+
+    @include mq(desktop) {
+        width:960px;
+    }
+
+    @include mq(leftCol) {
+        margin-left: -160px;
+        width: 1100px;
+    }
+    @include mq(wide) {
+        margin-left: -240px;
+        width: 1260px;
+    }
+}

--- a/shared/css/_scrolly.scss
+++ b/shared/css/_scrolly.scss
@@ -14,7 +14,7 @@
     }
 
     @include mq(leftCol) {
-        width: 1140px;
+        width: 1100px;
     }
     @include mq(wide) {
         width: 1260px;


### PR DESCRIPTION
Allow deploy to article page.

Before deploying to article page, do the following:

1.  Comment out code under INTERACTIVE header in `main.js` and uncomment code under ARTICLE header.
2. Comment out `@import "dcr_enhancer";` in `main.scss`
3. Change path in `config.json` to prevent overwriting atom for interactive page.