### PR TITLE
refactor(scrollyteller.js): iframe bound

### DIFF
--- a/shared/js/scrollyteller.js
+++ b/shared/js/scrollyteller.js
@@ -13,15 +13,13 @@ class ScrollyTeller {
         this.textBoxes = [].slice.apply(this.scrollText.querySelectorAll(".scroll-text__inner"));
         this.transparentUntilActive = config.transparentUntilActive;
 
-        this.scrollWrapper.style.height = this.textBoxes.length * 100 + "vh";
-
         if(this.transparentUntilActive) {
             config.parent.classList.add("transparent-until-active");
         }
     }
 
     checkScroll() {
-        if(this.lastScroll !== window.pageYOffset) {
+        if(this.lastScroll !== this.scrollWrapper.scrollTop) {
             const bbox = this.scrollText.getBoundingClientRect();
     
             if(!supportsSticky) {
@@ -59,7 +57,7 @@ class ScrollyTeller {
                 }
             }
     
-            this.lastScroll = window.pageYOffset;
+            this.lastScroll = this.scrollWrapper.scrollTop;
         }
     
         window.requestAnimationFrame(this.checkScroll.bind(this));

--- a/shared/js/scrollytellerProgress.js
+++ b/shared/js/scrollytellerProgress.js
@@ -22,6 +22,16 @@ class ScrollyTeller {
         if(this.transparentUntilActive) {
             config.parent.classList.add("transparent-until-active");
         }
+
+
+        window.addEventListener('message', (message) => {
+          if(typeof message !== "object" || typeof message == null) return;
+          if(!("kind" in message || !("height" in message)) return;
+          if(message.kind !== "interactive:scroll") return;
+          if(typeof message.height !== "number") return;
+
+          wrapper.scrollTo(0, message.data);
+        });
     }
 
     gradual( f ) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Work with https://github.com/guardian/dotcom-rendering/pull/9835

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
